### PR TITLE
Highlight Empty Cells When Pressing Solve

### DIFF
--- a/src/core/utility.hpp
+++ b/src/core/utility.hpp
@@ -30,8 +30,10 @@ struct overloaded : Ts...
 
 class timer
 {
+public:
     using clock = std::chrono::steady_clock;
 
+private:
     clock d_clock;
     clock::time_point d_prev_time;
     clock::time_point d_curr_time;
@@ -47,6 +49,9 @@ public:
 
     auto now() const -> clock::time_point;
 };
+
+using time_point = typename timer::clock::time_point;
+using namespace std::chrono_literals;
 
 auto random_from_range(float min, float max) -> float;
 auto random_from_range(int min, int max) -> int;

--- a/src/core/utility.hpp
+++ b/src/core/utility.hpp
@@ -159,4 +159,9 @@ inline auto is_in_region(glm::vec2 pos, glm::vec2 top_left, f32 width, f32 heigh
         && top_left.y <= pos.y && pos.y < top_left.y + height;
 }
 
+inline auto clamp(double val, double lo, double hi) -> double
+{
+    return std::min(std::max(lo, val), hi);
+}
+
 }

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -263,7 +263,8 @@ auto scene_game(sudoku::window& window) -> next_state
 
     auto solution = std::optional<bad_solution>{};
 
-#if 0
+#define LEVEL 2
+#if LEVEL == 0
     auto board = make_board(
         {
             "2..91.568",
@@ -287,7 +288,7 @@ auto scene_game(sudoku::window& window) -> next_state
             "777888999",
         }
     );
-#else
+#elif LEVEL == 1
     auto board = make_board(
         {
             "..57341",
@@ -305,6 +306,22 @@ auto scene_game(sudoku::window& window) -> next_state
             "4455663",
             "4777666",
             "4777766",
+        }
+    );
+#elif LEVEL == 2
+    auto board = make_board(
+        {
+            ".5...",
+            "...3.",
+            "5...1",
+            ".4...",
+            "...5."
+        }, {
+            "11112",
+            "13442",
+            "33442",
+            "33422",
+            "55555"
         }
     );
 #endif
@@ -347,7 +364,6 @@ auto scene_game(sudoku::window& window) -> next_state
         }
 
         if (ui.button("Back", {0, 0}, 200, 50, 3)) {
-            std::print("exiting!\n");
             return next_state::main_menu;
         }
 

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -54,12 +54,14 @@ auto hovered_cell(sudoku_board& board, const window& w) -> sudoku_cell*
 
 struct bad_solution
 {
+    time_point solve_time;
     std::unordered_set<glm::ivec2> empty_cells;
 };
 
-auto check_solution(const sudoku_board& board) -> std::optional<bad_solution>
+auto check_solution(const sudoku_board& board, time_point time) -> std::optional<bad_solution>
 {
     auto sol = bad_solution{};
+    sol.solve_time = time;
 
     // check for empty cells
     for (i32 row = 0; row != board.size(); ++row) {
@@ -252,8 +254,6 @@ auto scene_game(sudoku::window& window) -> next_state
     auto ui    = sudoku::ui_engine{&shapes};
 
     auto solution = std::optional<bad_solution>{};
-    auto counter = 0.0;
-    auto solve_time = 0.0;
 
 #if 0
     auto board = make_board(
@@ -305,8 +305,7 @@ auto scene_game(sudoku::window& window) -> next_state
         const double dt = timer.on_update();
         window.begin_frame(clear_colour);
 
-        counter += dt;
-        if (solution.has_value() && counter - solve_time > 5.0) {
+        if (solution.has_value() && timer.now() - solution->solve_time > 1s) {
             solution = {};
         }
 
@@ -345,12 +344,11 @@ auto scene_game(sudoku::window& window) -> next_state
         }
 
         if (ui.button("Check Solution", {0, 55}, 200, 50, 3)) {
-            const auto success = check_solution(board);
+            const auto success = check_solution(board, timer.now());
             solution = success;
             if (!success.has_value()) {
                 std::print("solved!\n");
             } else {
-                solve_time = counter;
                 std::print("bad!\n");
             }
         }

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -110,7 +110,14 @@ auto check_solution(const sudoku_board& board, time_point time) -> std::optional
     return std::nullopt;
 }
 
-auto draw_sudoku_board(renderer& r, const window& w, const sudoku_board& board, const std::optional<bad_solution>& sol) -> void
+auto draw_sudoku_board(
+    renderer& r,
+    const window& w,
+    const sudoku_board& board,
+    const std::optional<bad_solution>& sol,
+    const time_point& now
+)
+    -> void
 {
     constexpr auto colour_given_digits = from_hex(0xecf0f1);
     constexpr auto colour_added_digits = from_hex(0x1abc9c);
@@ -138,7 +145,8 @@ auto draw_sudoku_board(renderer& r, const window& w, const sudoku_board& board, 
             const auto highlighted = is_in_region(w.mouse_pos(), cell_top_left, cell_size, cell_size);
             auto cell_colour = highlighted ? colour_cell_hightlighted : colour_cell;
             if (sol.has_value() && sol->empty_cells.contains(glm::ivec2{x, y})) {
-                cell_colour = from_hex(0xc0392b);
+                const auto t = std::chrono::duration<double>(now - sol->solve_time).count();
+                cell_colour = lerp(from_hex(0xc0392b), cell_colour, t);
             }
             r.push_quad(cell_centre, cell_size, cell_size, 0, cell_colour);
 
@@ -348,12 +356,10 @@ auto scene_game(sudoku::window& window) -> next_state
             solution = success;
             if (!success.has_value()) {
                 std::print("solved!\n");
-            } else {
-                std::print("bad!\n");
             }
         }
 
-        draw_sudoku_board(shapes, window, board, solution);
+        draw_sudoku_board(shapes, window, board, solution, timer.now());
 
         ui.end_frame(dt);
 

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -59,12 +59,26 @@ struct bad_solution
 
 auto check_solution(const sudoku_board& board) -> std::optional<bad_solution>
 {
+    auto sol = bad_solution{};
+
+    // check for empty cells
+    for (i32 row = 0; row != board.size(); ++row) {
+        for (i32 col = 0; col != board.size(); ++col) {
+            const auto val = board.at(row, col).value;
+            if (!val.has_value()) {
+                sol.empty_cells.insert(glm::ivec2{row, col});
+            }
+        }
+    }
+    if (!sol.empty_cells.empty()) { // bad solution because the board isn't filled
+        return sol;
+    }
+
     // check rows
     for (i32 row = 0; row != board.size(); ++row) {
         std::unordered_set<i32> seen; 
         for (i32 col = 0; col != board.size(); ++col) {
             const auto val = board.at(row, col).value;
-            if (!val.has_value()) return bad_solution{};
             seen.insert(*val);
         }
         if (seen.size() != board.size()) return bad_solution{}; // duplicate values in the row


### PR DESCRIPTION
* When pressing the solve button, if a cell is empty, it flashes red. This is a bit of a messy implementation, there must be a better way.
* Rather than implementing more error checking yet, I want to implement other stuff first, hence the half baked PR.
* A retained approach may be better for the sudoku board, storing things such as conflicting numbers, but will try to just do it in immediate mode for now, given that the sudoku boards are so small. But it's likely not the best approach.