### PR TITLE
Pencil Marks

### DIFF
--- a/src/core/event.hpp
+++ b/src/core/event.hpp
@@ -28,6 +28,13 @@ enum class keyboard
 	num_0 = 48, num_1, num_2, num_3, num_4, num_5, num_6, num_7, num_8, num_9,
 };
 
+enum modifier // not an enum class because they can be | together
+{
+	shift = 1 << 0,
+	ctrl  = 1 << 1,
+	alt   = 1 << 2
+};
+
 // KEYBOARD EVENTS 
 struct keyboard_pressed_event {
 	keyboard key;

--- a/src/core/font.cpp
+++ b/src/core/font.cpp
@@ -12,7 +12,7 @@ auto font_atlas::get_character(char c) const -> const character&
     return missing_char;
 }
 
-auto font_atlas::length_of(std::string_view message) -> i32
+auto font_atlas::length_of(std::string_view message) const -> i32
 {
     if (message.empty()) {
         return 0;

--- a/src/core/font.hpp
+++ b/src/core/font.hpp
@@ -26,7 +26,7 @@ struct font_atlas
     i32                                 height; // height of an "a", used for centring
 
     auto get_character(char c) const -> const character&;
-    auto length_of(std::string_view message) -> i32;
+    auto length_of(std::string_view message) const -> i32;
 };
 
 }

--- a/src/core/renderer.hpp
+++ b/src/core/renderer.hpp
@@ -74,6 +74,8 @@ public:
     // Renders all queued up geometry
     void draw(i32 screen_width, i32 screen_height);
 
+    auto font() const -> const font_atlas& { return d_atlas; }
+
     // Queues up geometry to render
     void push_rect(glm::vec2 top_left, float width, float height, glm::vec4 colour);
     void push_quad(glm::vec2 centre, float width, float height, float angle, glm::vec4 colour);

--- a/src/core/sudoku.hpp
+++ b/src/core/sudoku.hpp
@@ -14,7 +14,7 @@ struct sudoku_cell
     bool               fixed = false;
     std::optional<i32> region = {};
 
-    //std::string corner_pencil_marks;
+    std::set<i32> corner_pencil_marks;
     std::set<i32> centre_pencil_marks;
 };
 

--- a/src/core/sudoku.hpp
+++ b/src/core/sudoku.hpp
@@ -2,6 +2,7 @@
 #include <optional>
 #include <vector>
 #include <print>
+#include <set>
 
 #include <glm/glm.hpp>
 
@@ -12,6 +13,9 @@ struct sudoku_cell
     std::optional<i32> value = {};
     bool               fixed = false;
     std::optional<i32> region = {};
+
+    //std::string corner_pencil_marks;
+    std::set<i32> centre_pencil_marks;
 };
 
 struct sudoku_region

--- a/src/core/utility.hpp
+++ b/src/core/utility.hpp
@@ -69,14 +69,14 @@ auto coin_flip() -> bool;
 auto sign_flip() -> int;
 auto random_unit() -> float; // Same as random_from_range(0.0f, 1.0f)
 
-constexpr auto from_hex(int hex) -> glm::vec4
+constexpr auto from_hex(int hex, float alpha = 1.0f) -> glm::vec4
 {
     const auto blue = static_cast<float>(hex & 0xff) / 256.0f;
     hex /= 0x100;
     const auto green = static_cast<float>(hex & 0xff) / 256.0f;
     hex /= 0x100;
     const auto red = static_cast<float>(hex & 0xff) / 256.0f;
-    return glm::vec4{red, green, blue, 1.0f};
+    return glm::vec4{red, green, blue, alpha};
 }
 
 auto get_executable_filepath() -> std::filesystem::path;

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -415,7 +415,13 @@ auto scene_game(sudoku::window& window) -> next_state
                         }
                         else {
                             if (*value == -1) {
-                                cell->value = {};
+                                if (cell->value.has_value()) {
+                                    cell->value = {};
+                                } else if (!cell->centre_pencil_marks.empty()) {
+                                    cell->centre_pencil_marks.clear();
+                                } else if (!cell->corner_pencil_marks.empty()) {
+                                    cell->corner_pencil_marks.clear();
+                                }
                             } else if (*value <= board.size()) {
                                 cell->value = *value;
                             }

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -184,8 +184,8 @@ auto draw_sudoku_board(
                         scale  = 1;
                     }
                     auto pos = cell_top_left;
-                    pos.x += (i32)(cell_size * 0.05f);
-                    pos.y += (i32)(cell_size * 0.05f) + r.font().height * scale;
+                    pos.x += (i32)(cell_size * 0.1f);
+                    pos.y += (i32)(cell_size * 0.1f) + r.font().height * scale;
                     r.push_text(s, pos, scale, colour);
                 }
 

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -160,7 +160,12 @@ auto draw_sudoku_board(
                 for (auto mark : cell.centre_pencil_marks) {
                     s.append(std::to_string(mark));
                 }
-                r.push_text_box(s, cell_top_left, cell_size, cell_size, 2, colour);
+                auto scale = 2;
+                auto length = scale * r.font().length_of(s);
+                if (length > cell_size) {
+                    scale  = 1;
+                }
+                r.push_text_box(s, cell_top_left, cell_size, cell_size, scale, colour);
             }
         }
     }
@@ -210,8 +215,8 @@ auto scene_main_menu(sudoku::window& window) -> next_state
 {
     using namespace sudoku;
     auto timer = sudoku::timer{};
-    auto shapes = sudoku::renderer{};
-    auto ui    = sudoku::ui_engine{&shapes};
+    auto renderer = sudoku::renderer{};
+    auto ui    = sudoku::ui_engine{&renderer};
 
     while (window.is_running()) {
         const double dt = timer.on_update();
@@ -239,22 +244,22 @@ auto scene_main_menu(sudoku::window& window) -> next_state
         const auto para_left = 100;
         const auto para_top = 300;
         constexpr auto colour = from_hex(0xecf0f1);
-        shapes.push_text("Lorem ipsum dolor sit amet, consectetur adipiscing elit,", {para_left, para_top}, scale, colour);
-        shapes.push_text("sed do eiusmod tempor incididunt ut labore et dolore magna", {para_left, para_top + 1 * 11 * scale}, scale, colour);
-        shapes.push_text("aliqua. Ut enim ad minim veniam, quis nostrud exercitation", {para_left, para_top + 2 * 11 * scale}, scale, colour);
-        shapes.push_text("ullamco laboris nisi ut aliquip ex ea commodo consequat.", {para_left, para_top + 3 * 11 * scale}, scale, colour);
-        shapes.push_text("Duis aute irure dolor in reprehenderit in voluptate velit", {para_left, para_top + 4 * 11 * scale}, scale, colour);
-        shapes.push_text("esse cillum dolore eu fugiat nulla pariatur. Excepteur", {para_left, para_top + 5 * 11 * scale}, scale, colour);
-        shapes.push_text("sint occaecat cupidatat non proident, sunt in culpa", {para_left, para_top + 6 * 11 * scale}, scale, colour);
-        shapes.push_text("qui officia deserunt mollit anim id est laborum.", {para_left, para_top + 7 * 11 * scale}, scale, colour);
-        shapes.push_text("ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz", {para_left, para_top + 8 * 11 * scale}, scale, colour);
-        shapes.push_text("0123456789 () {} [] ^ < > - _ = + ! ? : ; . , @ % $ / \\ \" ' # ~ & | `", {para_left, para_top + 9 * 11 * scale}, scale, colour);
+        renderer.push_text("Lorem ipsum dolor sit amet, consectetur adipiscing elit,", {para_left, para_top}, scale, colour);
+        renderer.push_text("sed do eiusmod tempor incididunt ut labore et dolore magna", {para_left, para_top + 1 * 11 * scale}, scale, colour);
+        renderer.push_text("aliqua. Ut enim ad minim veniam, quis nostrud exercitation", {para_left, para_top + 2 * 11 * scale}, scale, colour);
+        renderer.push_text("ullamco laboris nisi ut aliquip ex ea commodo consequat.", {para_left, para_top + 3 * 11 * scale}, scale, colour);
+        renderer.push_text("Duis aute irure dolor in reprehenderit in voluptate velit", {para_left, para_top + 4 * 11 * scale}, scale, colour);
+        renderer.push_text("esse cillum dolore eu fugiat nulla pariatur. Excepteur", {para_left, para_top + 5 * 11 * scale}, scale, colour);
+        renderer.push_text("sint occaecat cupidatat non proident, sunt in culpa", {para_left, para_top + 6 * 11 * scale}, scale, colour);
+        renderer.push_text("qui officia deserunt mollit anim id est laborum.", {para_left, para_top + 7 * 11 * scale}, scale, colour);
+        renderer.push_text("ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz", {para_left, para_top + 8 * 11 * scale}, scale, colour);
+        renderer.push_text("0123456789 () {} [] ^ < > - _ = + ! ? : ; . , @ % $ / \\ \" ' # ~ & | `", {para_left, para_top + 9 * 11 * scale}, scale, colour);
 
         std::array<char, 8> buf = {};
-        shapes.push_text_box(sudoku::format_to(buf, "{}", timer.frame_rate()), {0, 0}, 120, 50, 3, colour);
+        renderer.push_text_box(sudoku::format_to(buf, "{}", timer.frame_rate()), {0, 0}, 120, 50, 3, colour);
         ui.end_frame(dt);
 
-        shapes.draw(window.width(), window.height());
+        renderer.draw(window.width(), window.height());
         window.end_frame();
     }
 


### PR DESCRIPTION
<img width="250" height="244" alt="image" src="https://github.com/user-attachments/assets/e3e44891-6de2-471b-818d-d53d514839f8" />

* Added ability to add corner and central pencil marks.
* Corner marks are added by holding shift.
* Centre marks are added by holding control.
* With pencil marks, pressing numbers repeatedly toggles the value.
* If you fill a big value and try to enter that again, it will also toggle it.
* The code is getting close to needing a serious refactor.