### PR TITLE
Select Cells Instead of Hover

### DIFF
--- a/src/core/sudoku.hpp
+++ b/src/core/sudoku.hpp
@@ -61,6 +61,7 @@ public:
     }
 
     auto cells() -> std::vector<sudoku_cell>& { return d_cells; }
+    auto cells() const -> const std::vector<sudoku_cell>& { return d_cells; }
 };
 
 inline auto make_board(std::vector<std::string_view> cells, std::vector<std::string_view> regions) -> sudoku_board

--- a/src/core/sudoku.hpp
+++ b/src/core/sudoku.hpp
@@ -1,9 +1,12 @@
 #pragma once
 #include <optional>
 #include <vector>
+#include <unordered_set>
 #include <print>
 #include <set>
 
+#define GLM_ENABLE_EXPERIMENTAL
+#include <glm/gtx/hash.hpp>
 #include <glm/glm.hpp>
 
 namespace sudoku {
@@ -25,8 +28,9 @@ struct sudoku_region
 
 class sudoku_board
 {
-    u64                        d_size;
-    std::vector<sudoku_cell>   d_cells;
+    u64                            d_size;
+    std::vector<sudoku_cell>       d_cells;
+    std::unordered_set<glm::ivec2> d_selected;
 
 public:
     sudoku_board(u64 size)
@@ -34,21 +38,32 @@ public:
     {
     }
 
-    auto at(u64 x, u64 y) -> sudoku_cell& {
-        assert(x < d_size);
-        assert(y < d_size);
+    auto at(i32 x, i32 y) -> sudoku_cell& {
+        assert(valid(x, y));
         return d_cells[x + y * d_size];
     }
 
-    auto at(u64 x, u64 y) const -> const sudoku_cell& {
-        assert(x < d_size);
-        assert(y < d_size);
+    auto at(i32 x, i32 y) const -> const sudoku_cell& {
+        assert(valid(x, y));
         return d_cells[x + y * d_size];
     }
 
     auto size() const -> u64 {
         return d_size;
     }
+
+    auto valid(i32 x, i32 y) -> bool {
+        return 0 <= x && x < d_size && 0 <= y && y < d_size;
+    }
+
+    auto selected() -> std::unordered_set<glm::ivec2>& {
+        return d_selected;
+    }
+
+    auto selected() const -> const std::unordered_set<glm::ivec2>& {
+        return d_selected;
+    }
+
 };
 
 inline auto make_board(std::vector<std::string_view> cells, std::vector<std::string_view> regions) -> sudoku_board

--- a/src/core/sudoku.hpp
+++ b/src/core/sudoku.hpp
@@ -16,6 +16,7 @@ struct sudoku_cell
     std::optional<i32> value = {};
     bool               fixed = false;
     std::optional<i32> region = {};
+    bool               selected = false;
 
     std::set<i32> corner_pencil_marks;
     std::set<i32> centre_pencil_marks;
@@ -30,7 +31,6 @@ class sudoku_board
 {
     u64                            d_size;
     std::vector<sudoku_cell>       d_cells;
-    std::unordered_set<glm::ivec2> d_selected;
 
 public:
     sudoku_board(u64 size)
@@ -56,14 +56,11 @@ public:
         return 0 <= x && x < d_size && 0 <= y && y < d_size;
     }
 
-    auto selected() -> std::unordered_set<glm::ivec2>& {
-        return d_selected;
+    auto clear_selected() -> void {
+        for (auto& cell : d_cells) cell.selected = false;
     }
 
-    auto selected() const -> const std::unordered_set<glm::ivec2>& {
-        return d_selected;
-    }
-
+    auto cells() -> std::vector<sudoku_cell>& { return d_cells; }
 };
 
 inline auto make_board(std::vector<std::string_view> cells, std::vector<std::string_view> regions) -> sudoku_board

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -381,7 +381,6 @@ auto scene_game(sudoku::window& window) -> next_state
                 const auto cell_pos = hovered_cell_pos(board, window);
                 if (cell_pos.has_value() && board.valid(cell_pos->x, cell_pos->y)) {
                     if (e->button == mouse::left) {
-                        std::print("inserting position\n");
                         if (e->mods & modifier::shift) {
                             board.selected().insert(*cell_pos);
                         } else {
@@ -389,19 +388,25 @@ auto scene_game(sudoku::window& window) -> next_state
                             board.selected().insert(*cell_pos);
                         }
                     }
+                } else {
+                    board.selected().clear();
                 }
             }
             else if (auto e = event.get_if<keyboard_pressed_event>()) {
-                if (auto cell = hovered_cell(board, window); cell && !cell->fixed) {
+                for (const auto pos : board.selected()) {
+                    if (!board.valid(pos.x, pos.y) || board.at(pos.x, pos.y).fixed) {
+                        continue;
+                    }
+                    auto& cell = board.at(pos.x, pos.y);
                     std::optional<i32> value = {};
                     switch (e->key) {
                         case keyboard::backspace: {
-                            if (cell->value.has_value()) {
-                                cell->value = {};
-                            } else if (!cell->centre_pencil_marks.empty()) {
-                                cell->centre_pencil_marks.clear();
-                            } else if (!cell->corner_pencil_marks.empty()) {
-                                cell->corner_pencil_marks.clear();
+                            if (cell.value.has_value()) {
+                                cell.value = {};
+                            } else if (!cell.centre_pencil_marks.empty()) {
+                                cell.centre_pencil_marks.clear();
+                            } else if (!cell.corner_pencil_marks.empty()) {
+                                cell.corner_pencil_marks.clear();
                             }
                         } break;
                         case keyboard::num_1: value = 1; break;
@@ -418,13 +423,13 @@ auto scene_game(sudoku::window& window) -> next_state
                     if (*value > board.size()) continue; // not a digit in the grid
 
                     if (e->mods & modifier::ctrl) {
-                        flip(cell->centre_pencil_marks, *value);
+                        flip(cell.centre_pencil_marks, *value);
                     }
                     else if (e->mods & modifier::shift) {
-                        flip(cell->corner_pencil_marks, *value);
+                        flip(cell.corner_pencil_marks, *value);
                     }
                     else {
-                        cell->value = *value;
+                        cell.value = *value;
                     }
                 }
             }

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -497,7 +497,7 @@ auto scene_game(sudoku::window& window) -> next_state
                 if (cell != nullptr) {
                     if (e->button == mouse::left) {
                         if (e->mods & modifier::shift) {
-                            cell->selected = true;
+                            cell->selected = !cell->selected;
                         } else {
                             board.clear_selected();
                             cell->selected = true;

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -519,6 +519,9 @@ auto scene_game(sudoku::window& window) -> next_state
                             clear_corner_pencil_mark(board);
                         }
                     } break;
+                    case keyboard::escape: {
+                        board.clear_selected();
+                    } break;
                     case keyboard::num_1: value = 1; break;
                     case keyboard::num_2: value = 2; break;
                     case keyboard::num_3: value = 3; break;

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -153,7 +153,7 @@ auto draw_sudoku_board(
             }
             if (cell_colour != colour_cell) {
                 r.push_quad(cell_centre, cell_size, cell_size, 0, cell_colour);
-            } else if (board.selected().contains(glm::ivec2{x, y})) {
+            } else if (board.at(x, y).selected) {
                 r.push_quad(cell_centre, cell_size, cell_size, 0, colour_cell_hightlighted);
             }
 
@@ -378,26 +378,25 @@ auto scene_game(sudoku::window& window) -> next_state
             ui.on_event(event);
 
             if (auto e = event.get_if<mouse_pressed_event>()) {
-                const auto cell_pos = hovered_cell_pos(board, window);
-                if (cell_pos.has_value() && board.valid(cell_pos->x, cell_pos->y)) {
+                auto cell = hovered_cell(board, window);
+                if (cell != nullptr) {
                     if (e->button == mouse::left) {
                         if (e->mods & modifier::shift) {
-                            board.selected().insert(*cell_pos);
+                            cell->selected = true;
                         } else {
-                            board.selected().clear();
-                            board.selected().insert(*cell_pos);
+                            board.clear_selected();
+                            cell->selected = true;
                         }
                     }
                 } else {
-                    board.selected().clear();
+                    board.clear_selected();
                 }
             }
             else if (auto e = event.get_if<keyboard_pressed_event>()) {
-                for (const auto pos : board.selected()) {
-                    if (!board.valid(pos.x, pos.y) || board.at(pos.x, pos.y).fixed) {
+                for (auto& cell : board.cells()) {
+                    if (cell.fixed || !cell.selected) {
                         continue;
                     }
-                    auto& cell = board.at(pos.x, pos.y);
                     std::optional<i32> value = {};
                     switch (e->key) {
                         case keyboard::backspace: {


### PR DESCRIPTION
<img width="235" height="234" alt="image" src="https://github.com/user-attachments/assets/3e208404-a204-4b33-a98f-1c5d3b2eac5d" />

* Rather than updating the currently hovered cell, you now have to click them to update them.
* More than one cell can be selected and updated at the same time.
* Hold shift while clicking to select more.
* Shift-clicking a selected cell unselects it.