### PR TITLE
Undo/Redo Controls

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(core STATIC
     ui.cpp
     sudoku.cpp
     draw_board.cpp
+    solve_history.cpp
 )
 
 target_include_directories(core PUBLIC .)

--- a/src/core/draw_board.cpp
+++ b/src/core/draw_board.cpp
@@ -48,7 +48,7 @@ auto draw_highlighted(renderer& r, const sudoku_board& board, const render_confi
 {
     for (int y = 0; y != board.size(); ++y) {
         for (int x = 0; x != board.size(); ++x) {
-            if (board.at(x, y).selected) {
+            if (board.at({x, y}).selected) {
                 const auto cell_centre = config.tl + config.cell_size * glm::vec2{x + 0.5f, y + 0.5f};
                 r.push_quad(cell_centre, config.cell_size, config.cell_size, 0, colour_cell_hightlighted);
             }
@@ -77,13 +77,13 @@ auto draw_constraints(renderer& r, const sudoku_board& board, const board_render
     // draw the boundaries of the regions
     for (i32 x = 0; x != board.size(); ++x) {
         for (i32 y = 0; y != board.size(); ++y) {
-            if (x + 1 < board.size() && board.at(x, y).region != board.at(x + 1, y).region) {
+            if (x + 1 < board.size() && board.at({x, y}).region != board.at({x + 1, y}).region) {
                 const auto a = config.tl + config.cell_size * glm::vec2{x + 1, y};
                 const auto b = config.tl + config.cell_size * glm::vec2{x + 1, y + 1};
                 r.push_line(a, b, from_hex(0xecf0f1), 1.f);
             }
 
-            if (y + 1 < board.size() && board.at(x, y).region != board.at(x, y + 1).region) {
+            if (y + 1 < board.size() && board.at({x, y}).region != board.at({x, y + 1}).region) {
                 const auto a = config.tl + config.cell_size * glm::vec2{x,     y + 1};
                 const auto b = config.tl + config.cell_size * glm::vec2{x + 1, y + 1};
                 r.push_line(a, b, from_hex(0xecf0f1), 1.f);
@@ -119,7 +119,7 @@ auto draw_digits(renderer& r, const sudoku_board& board, const board_render_stat
         for (int x = 0; x != board.size(); ++x) {
             const auto cell_top_left = config.tl + config.cell_size * glm::vec2{x, y};
 
-            const auto& cell = board.at(x, y);
+            const auto& cell = board.at({x, y});
             if (cell.value.has_value()) {
                 auto colour = cell.fixed ? colour_given_digits : colour_added_digits;
                 auto scale = 6;

--- a/src/core/solve_history.cpp
+++ b/src/core/solve_history.cpp
@@ -11,7 +11,6 @@ void solve_history::add_event(const edit_event& event)
     }
     d_events.push_back(event);
     d_curr = d_events.size();
-    std::print("added event!\n");
 }
 
 auto solve_history::go_back() -> std::optional<edit_event>

--- a/src/core/solve_history.cpp
+++ b/src/core/solve_history.cpp
@@ -12,6 +12,9 @@ void solve_history::add_event(const edit_event& event)
         d_events.resize(d_curr); // if we've gone back and then made an edit, remove all forward history
     }
     d_events.push_back(event);
+    if (d_events.size() > 1024) { // only keep the last 1024 history
+        d_events.pop_front();
+    }
     d_curr = d_events.size();
 }
 

--- a/src/core/solve_history.cpp
+++ b/src/core/solve_history.cpp
@@ -1,0 +1,27 @@
+#include "solve_history.hpp"
+
+namespace sudoku {
+
+void solve_history::add_event(const edit_event& event)
+{
+    d_events.resize(d_curr); // if we've gone back and then made an edit, remove all forward history
+    d_events.push_back(event);
+    d_curr = d_events.size();
+}
+
+auto solve_history::go_back() -> std::optional<edit_event>
+{
+    if (d_curr == 0) { return std::nullopt; }
+    --d_curr;
+    return d_events.at(d_curr);
+}
+
+auto solve_history::go_forward() -> std::optional<edit_event>
+{
+    if (d_curr == d_events.size()) { return std::nullopt; }
+    const auto ret = d_events.at(d_curr);
+    ++d_curr;
+    return ret;
+}
+
+}

--- a/src/core/solve_history.cpp
+++ b/src/core/solve_history.cpp
@@ -15,7 +15,7 @@ void dump_event(const edit_event& event)
 {
     std::print("event:\n");
     for (const auto& diff : event.diffs) {
-        std::print("  - pos = [{}, {}], kind = {}, old_value = {}, new_value = {}\n", diff.pos.x, diff.pos.y, (i32)diff.kind, to_string(diff.old_value), to_string(diff.new_value));
+        //std::print("  - pos = [{}, {}], kind = {}, old_value = {}, new_value = {}\n", diff.pos.x, diff.pos.y, (i32)diff.kind, to_string(diff.old_value), to_string(diff.new_value));
     }
 }
 

--- a/src/core/solve_history.cpp
+++ b/src/core/solve_history.cpp
@@ -14,46 +14,14 @@ auto to_string(std::optional<i32> val) -> std::string
 void dump_event(const edit_event& event)
 {
     std::print("event:\n");
-    for (const auto& [pos, change] : event.changes) {
-        std::print("    pos = [{}, {}]\n", pos.x, pos.y);
-        std::print("        changed = {}\n", change.changed);
-        std::print("        from = {}\n", to_string(change.from));
-        std::print("        to = {}\n", to_string(change.to));
-
-        std::print("        centre_marks_added:");
-        for (const auto val : change.centre_marks_added) {
-            std::print(" {}", val);
-        }
-        std::print("\n");
-        std::print("        centre_marks_removed:");
-        for (const auto val : change.centre_marks_removed) {
-            std::print(" {}", val);
-        }
-        std::print("\n");
-
-        std::print("        corner_marks_added:");
-        for (const auto val : change.corner_marks_added) {
-            std::print(" {}", val);
-        }
-        std::print("\n");
-        std::print("        corner_marks_removed:");
-        for (const auto val : change.corner_marks_removed) {
-            std::print(" {}", val);
-        }
-        std::print("\n");
+    for (const auto& diff : event.diffs) {
+        std::print("  - pos = [{}, {}], kind = {}, old_value = {}, new_value = {}\n", diff.pos.x, diff.pos.y, (i32)diff.kind, to_string(diff.old_value), to_string(diff.new_value));
     }
 }
 
 auto is_empty_event(const edit_event& event) -> bool
 {
-    for (const auto& [pos, change] : event.changes) {
-        if (change.changed) return false;
-        if (!change.centre_marks_added.empty()) return false;
-        if (!change.centre_marks_removed.empty()) return false;
-        if (!change.corner_marks_added.empty()) return false;
-        if (!change.corner_marks_removed.empty()) return false;
-    }
-    return true;
+    return event.diffs.empty();
 }
 
 }
@@ -61,7 +29,6 @@ auto is_empty_event(const edit_event& event) -> bool
 void solve_history::add_event(const edit_event& event)
 {
     if (is_empty_event(event)) return; // don't bother recording empty events
-    dump_event(event);
     if (d_curr < d_events.size()) {
         d_events.resize(d_curr); // if we've gone back and then made an edit, remove all forward history
     }

--- a/src/core/solve_history.cpp
+++ b/src/core/solve_history.cpp
@@ -3,9 +3,65 @@
 #include <print>
 
 namespace sudoku {
+namespace {
+
+auto to_string(std::optional<i32> val) -> std::string
+{
+    if (val) return std::format("{}", *val);
+    return "null";
+}
+
+void dump_event(const edit_event& event)
+{
+    std::print("event:\n");
+    for (const auto& [pos, change] : event.changes) {
+        std::print("    pos = [{}, {}]\n", pos.x, pos.y);
+        std::print("        changed = {}\n", change.changed);
+        std::print("        from = {}\n", to_string(change.from));
+        std::print("        to = {}\n", to_string(change.to));
+
+        std::print("        centre_marks_added:");
+        for (const auto val : change.centre_marks_added) {
+            std::print(" {}", val);
+        }
+        std::print("\n");
+        std::print("        centre_marks_removed:");
+        for (const auto val : change.centre_marks_removed) {
+            std::print(" {}", val);
+        }
+        std::print("\n");
+
+        std::print("        corner_marks_added:");
+        for (const auto val : change.corner_marks_added) {
+            std::print(" {}", val);
+        }
+        std::print("\n");
+        std::print("        corner_marks_removed:");
+        for (const auto val : change.corner_marks_removed) {
+            std::print(" {}", val);
+        }
+        std::print("\n");
+    }
+}
+
+auto is_empty_event(const edit_event& event) -> bool
+{
+    for (const auto& [pos, change] : event.changes) {
+        if (change.changed) return false;
+        if (!change.centre_marks_added.empty()) return false;
+        if (!change.centre_marks_removed.empty()) return false;
+        if (!change.corner_marks_added.empty()) return false;
+        if (!change.corner_marks_removed.empty()) return false;
+    }
+    return true;
+}
+
+}
 
 void solve_history::add_event(const edit_event& event)
 {
+    if (is_empty_event(event)) return; // don't bother recording empty events
+    dump_event(event);
     if (d_curr < d_events.size()) {
         d_events.resize(d_curr); // if we've gone back and then made an edit, remove all forward history
     }

--- a/src/core/solve_history.cpp
+++ b/src/core/solve_history.cpp
@@ -1,34 +1,13 @@
 #include "solve_history.hpp"
+#include "utility.hpp"
 
 #include <print>
 
 namespace sudoku {
-namespace {
-
-auto to_string(std::optional<i32> val) -> std::string
-{
-    if (val) return std::format("{}", *val);
-    return "null";
-}
-
-void dump_event(const edit_event& event)
-{
-    std::print("event:\n");
-    for (const auto& diff : event.diffs) {
-        //std::print("  - pos = [{}, {}], kind = {}, old_value = {}, new_value = {}\n", diff.pos.x, diff.pos.y, (i32)diff.kind, to_string(diff.old_value), to_string(diff.new_value));
-    }
-}
-
-auto is_empty_event(const edit_event& event) -> bool
-{
-    return event.diffs.empty();
-}
-
-}
 
 void solve_history::add_event(const edit_event& event)
 {
-    if (is_empty_event(event)) return; // don't bother recording empty events
+    if (event.empty()) return; // don't bother recording empty events
     if (d_curr < d_events.size()) {
         d_events.resize(d_curr); // if we've gone back and then made an edit, remove all forward history
     }

--- a/src/core/solve_history.cpp
+++ b/src/core/solve_history.cpp
@@ -1,12 +1,17 @@
 #include "solve_history.hpp"
 
+#include <print>
+
 namespace sudoku {
 
 void solve_history::add_event(const edit_event& event)
 {
-    d_events.resize(d_curr); // if we've gone back and then made an edit, remove all forward history
+    if (d_curr < d_events.size()) {
+        d_events.resize(d_curr); // if we've gone back and then made an edit, remove all forward history
+    }
     d_events.push_back(event);
     d_curr = d_events.size();
+    std::print("added event!\n");
 }
 
 auto solve_history::go_back() -> std::optional<edit_event>

--- a/src/core/solve_history.hpp
+++ b/src/core/solve_history.hpp
@@ -3,27 +3,35 @@
 
 #include <vector>
 #include <optional>
-#include <unordered_map>
-#include <unordered_set>
+#include <set>
+#include <variant>
 
 #include <glm/glm.hpp>
 
 namespace sudoku {
 
-enum class diff_kind
+struct digit_diff
 {
-    digit,
-    centre,
-    corner,
-};
-
-struct diff
-{
-    glm::ivec2         pos;
-    diff_kind          kind;
+    glm::ivec2 pos;
     std::optional<i32> old_value;
     std::optional<i32> new_value;
 };
+
+struct centre_diff
+{
+    glm::ivec2    pos;
+    bool          added;
+    std::set<i32> values;
+};
+
+struct corner_diff
+{
+    glm::ivec2    pos;
+    bool          added;
+    std::set<i32> values;
+};
+
+using diff = std::variant<digit_diff, corner_diff, centre_diff>;
 
 struct edit_event
 {

--- a/src/core/solve_history.hpp
+++ b/src/core/solve_history.hpp
@@ -12,6 +12,21 @@
 
 namespace sudoku {
 
+enum class diff_kind
+{
+    digit,
+    centre,
+    corner,
+};
+
+struct diff
+{
+    glm::ivec2         pos;
+    diff_kind          kind;
+    std::optional<i32> old_value;
+    std::optional<i32> new_value;
+};
+
 struct value_change
 {
     // Digit change
@@ -28,7 +43,8 @@ struct value_change
 
 struct edit_event
 {
-    std::unordered_map<glm::ivec2, value_change> changes;
+    //std::unordered_map<glm::ivec2, value_change> changes;
+    std::vector<diff> diffs;
 };
 
 class solve_history

--- a/src/core/solve_history.hpp
+++ b/src/core/solve_history.hpp
@@ -12,31 +12,29 @@ namespace sudoku {
 
 struct digit_diff
 {
-    glm::ivec2 pos;
     std::optional<i32> old_value;
     std::optional<i32> new_value;
 };
 
 struct centre_diff
 {
-    glm::ivec2    pos;
     bool          added;
     std::set<i32> values;
 };
 
 struct corner_diff
 {
-    glm::ivec2    pos;
     bool          added;
     std::set<i32> values;
 };
 
-using diff = std::variant<digit_diff, corner_diff, centre_diff>;
-
-struct edit_event
+struct diff
 {
-    std::vector<diff> diffs;
+    glm::ivec2                                         pos;
+    std::variant<digit_diff, corner_diff, centre_diff> data;
 };
+
+using edit_event = std::vector<diff>;
 
 class solve_history
 {

--- a/src/core/solve_history.hpp
+++ b/src/core/solve_history.hpp
@@ -6,9 +6,7 @@
 #include <unordered_map>
 #include <unordered_set>
 
-#define GLM_ENABLE_EXPERIMENTAL
 #include <glm/glm.hpp>
-#include <glm/gtx/hash.hpp>
 
 namespace sudoku {
 
@@ -27,23 +25,8 @@ struct diff
     std::optional<i32> new_value;
 };
 
-struct value_change
-{
-    // Digit change
-    bool changed = false;
-    std::optional<i32> from;
-    std::optional<i32> to;
-
-    std::unordered_set<i32> corner_marks_added;
-    std::unordered_set<i32> corner_marks_removed;
-
-    std::unordered_set<i32> centre_marks_added;
-    std::unordered_set<i32> centre_marks_removed;
-};
-
 struct edit_event
 {
-    //std::unordered_map<glm::ivec2, value_change> changes;
     std::vector<diff> diffs;
 };
 

--- a/src/core/solve_history.hpp
+++ b/src/core/solve_history.hpp
@@ -1,8 +1,11 @@
 #pragma once
 #include <vector>
 #include <optional>
+#include <unordered_set>
 
+#define GLM_ENABLE_EXPERIMENTAL
 #include <glm/glm.hpp>
+#include <glm/gtx/hash.hpp>
 
 namespace sudoku {
 
@@ -15,9 +18,9 @@ enum class edit_type
 
 struct edit_event
 {
-    edit_type  type;
-    bool       added;
-    glm::ivec2 pos;  
+    edit_type                      type;
+    bool                           added;
+    std::unordered_set<glm::ivec2> positions;  
 };
 
 class solve_history

--- a/src/core/solve_history.hpp
+++ b/src/core/solve_history.hpp
@@ -2,6 +2,7 @@
 #include "common.hpp"
 
 #include <vector>
+#include <deque>
 #include <optional>
 #include <set>
 #include <variant>
@@ -38,8 +39,8 @@ using edit_event = std::vector<diff>;
 
 class solve_history
 {
-    std::vector<edit_event> d_events;
-    std::size_t             d_curr;
+    std::deque<edit_event> d_events;
+    std::size_t            d_curr;
 
 public:
     solve_history() = default;

--- a/src/core/solve_history.hpp
+++ b/src/core/solve_history.hpp
@@ -1,6 +1,9 @@
 #pragma once
+#include "common.hpp"
+
 #include <vector>
 #include <optional>
+#include <unordered_map>
 #include <unordered_set>
 
 #define GLM_ENABLE_EXPERIMENTAL
@@ -9,18 +12,23 @@
 
 namespace sudoku {
 
-enum class edit_type
+struct value_change
 {
-    digit,
-    corner_pencil_mark,
-    centre_pencil_mark,
+    // Digit change
+    bool changed = false;
+    std::optional<i32> from;
+    std::optional<i32> to;
+
+    std::unordered_set<i32> corner_marks_added;
+    std::unordered_set<i32> corner_marks_removed;
+
+    std::unordered_set<i32> centre_marks_added;
+    std::unordered_set<i32> centre_marks_removed;
 };
 
 struct edit_event
 {
-    edit_type                      type;
-    bool                           added;
-    std::unordered_set<glm::ivec2> positions;  
+    std::unordered_map<glm::ivec2, value_change> changes;
 };
 
 class solve_history

--- a/src/core/solve_history.hpp
+++ b/src/core/solve_history.hpp
@@ -1,0 +1,37 @@
+#pragma once
+#include <vector>
+#include <optional>
+
+#include <glm/glm.hpp>
+
+namespace sudoku {
+
+enum class edit_type
+{
+    digit,
+    corner_pencil_mark,
+    centre_pencil_mark,
+};
+
+struct edit_event
+{
+    edit_type  type;
+    bool       added;
+    glm::ivec2 pos;  
+};
+
+class solve_history
+{
+    std::vector<edit_event> d_events;
+    std::size_t             d_curr;
+
+public:
+    solve_history() = default;
+
+    void add_event(const edit_event& event);
+
+    auto go_back() -> std::optional<edit_event>;
+    auto go_forward() -> std::optional<edit_event>;
+};
+
+}

--- a/src/core/sudoku.cpp
+++ b/src/core/sudoku.cpp
@@ -42,24 +42,58 @@ auto sudoku_board::set_digit(i32 value) -> void
     }
 }
 
-auto sudoku_board::set_corner_pencil_mark(i32 value) -> void
+auto sudoku_board::set_corner_pencil_mark(i32 value, bool add) -> void
 {
     for (auto& cell : d_cells) {
         if (cell.selected && !cell.fixed) {
-            cell.corner_pencil_marks.insert(value);
+            if (add) {
+                cell.corner_pencil_marks.insert(value);
+            } else {
+                cell.corner_pencil_marks.erase(value);
+            }
         }
     }
 }
 
-auto sudoku_board::set_centre_pencil_mark(i32 value) -> void
+auto sudoku_board::set_centre_pencil_mark(i32 value, bool add) -> void
 {
     for (auto& cell : d_cells) {
         if (cell.selected && !cell.fixed) {
-            cell.centre_pencil_marks.insert(value);
+            if (add) {
+                cell.centre_pencil_marks.insert(value);
+            } else {
+                cell.centre_pencil_marks.erase(value);
+            }
         }
     }
 }
 
+void sudoku_board::clear_corner_pencil_marks()
+{
+    for (auto& cell : d_cells) {
+        if (cell.selected && !cell.fixed) {
+            cell.corner_pencil_marks.clear();
+        }
+    }
+}
+
+void sudoku_board::clear_centre_pencil_marks()
+{
+    for (auto& cell : d_cells) {
+        if (cell.selected && !cell.fixed) {
+            cell.centre_pencil_marks.clear();
+        }
+    }
+}
+
+void sudoku_board::clear_digits()
+{
+    for (auto& cell : d_cells) {
+        if (cell.selected && !cell.fixed) {
+            cell.value = {};
+        }
+    }
+}
 
 auto sudoku_board::size() const -> u64
 {
@@ -71,13 +105,15 @@ auto sudoku_board::valid(glm::ivec2 pos) -> bool
     return 0 <= pos.x && pos.x < d_size && 0 <= pos.y && pos.y < d_size;
 }
 
-auto sudoku_board::clear_selected() -> void 
+auto sudoku_board::unselect_all() -> void 
 {
     for (auto& cell : d_cells) cell.selected = false;
 }
 
-auto sudoku_board::cells() -> std::vector<sudoku_cell>& { return d_cells; }
-auto sudoku_board::cells() const -> const std::vector<sudoku_cell>& { return d_cells; }
+auto sudoku_board::cells() const -> const std::vector<sudoku_cell>&
+{
+    return d_cells;
+}
 
 auto sudoku_board::make_board(std::vector<std::string_view> cells, std::vector<std::string_view> regions) -> sudoku_board
 {

--- a/src/core/sudoku.cpp
+++ b/src/core/sudoku.cpp
@@ -92,31 +92,71 @@ auto sudoku_board::set_centre_pencil_mark(i32 value) -> void
     }
 }
 
-void sudoku_board::clear_corner_pencil_marks()
+namespace { // TODO: Merge all this logic together
+
+auto has_any_value(const sudoku_board& board) -> bool
 {
-    for (auto& cell : d_cells) {
+    for (auto& cell : board.cells()) {
         if (cell.selected && !cell.fixed) {
-            cell.corner_pencil_marks.clear();
+            if (cell.value.has_value()) return true;
+        }
+    }
+    return false;
+}
+
+auto has_any_centre_pencil_marks(const sudoku_board& board) -> bool
+{
+    for (auto& cell : board.cells()) {
+        if (cell.selected && !cell.fixed) {
+            if (!cell.centre_pencil_marks.empty()) return true;
+        }
+    }
+    return false;
+}
+
+auto has_any_corner_pencil_marks(const sudoku_board& board) -> bool
+{
+    for (auto& cell : board.cells()) {
+        if (cell.selected && !cell.fixed) {
+            if (!cell.corner_pencil_marks.empty()) return true;
+        }
+    }
+    return false;
+}
+
+}
+
+void sudoku_board::clear_selected()
+{
+    if (has_any_value(*this)) {
+        for (auto& cell : d_cells) {
+            if (cell.selected && !cell.fixed) {
+                cell.value = {};
+            }
+        }
+    } else if (has_any_centre_pencil_marks(*this)) {
+        for (auto& cell : d_cells) {
+            if (cell.selected && !cell.fixed) {
+                cell.centre_pencil_marks.clear();
+            }
+        }
+    } else if (has_any_corner_pencil_marks(*this)) {
+        for (auto& cell : d_cells) {
+            if (cell.selected && !cell.fixed) {
+                cell.corner_pencil_marks.clear();
+            }
         }
     }
 }
 
-void sudoku_board::clear_centre_pencil_marks()
+void sudoku_board::undo()
 {
-    for (auto& cell : d_cells) {
-        if (cell.selected && !cell.fixed) {
-            cell.centre_pencil_marks.clear();
-        }
-    }
+
 }
 
-void sudoku_board::clear_digits()
+void sudoku_board::redo()
 {
-    for (auto& cell : d_cells) {
-        if (cell.selected && !cell.fixed) {
-            cell.value = {};
-        }
-    }
+
 }
 
 auto sudoku_board::size() const -> u64

--- a/src/core/sudoku.cpp
+++ b/src/core/sudoku.cpp
@@ -14,6 +14,16 @@ auto sudoku_board::get(glm::ivec2 pos) -> sudoku_cell&
     return d_cells[pos.x + pos.y * d_size];
 }
 
+auto sudoku_board::for_each_selected(const std::function<void(int, int, sudoku_cell&)>& fn)
+{
+    for (i32 x = 0; x != d_size; ++x) {
+        for (i32 y = 0; y != d_size; ++y) {
+            auto& cell = get({x, y});
+            if (cell.selected && !cell.fixed) fn(x, y, cell);
+        }
+    }
+}
+
 auto sudoku_board::at(glm::ivec2 pos) const -> const sudoku_cell&
 {
     assert(valid(pos));
@@ -35,15 +45,27 @@ auto sudoku_board::toggle_selected(glm::ivec2 pos) -> void
 
 auto sudoku_board::set_digit(i32 value) -> void
 {
-    for (auto& cell : d_cells) {
-        if (cell.selected && !cell.fixed) {
-            cell.value = value;
+    auto event = edit_event{};
+
+    for (i32 x = 0; x != d_size; ++x) {
+        for (i32 y = 0; y != d_size; ++y) {
+            auto& cell = get({x, y});
+            if (cell.selected && !cell.fixed) {
+                event.changes[{x, y}].changed = true;
+                event.changes[{x, y}].from = cell.value;
+                event.changes[{x, y}].to = value;
+                cell.value = value;
+            }
         }
     }
+
+    d_history.add_event(event);
 }
 
 auto sudoku_board::set_corner_pencil_mark(i32 value) -> void
 {
+    auto event = edit_event{};
+
     // If any of the cells can accept the pencil mark, we are adding, otherwise
     // we are removing
     bool add = false;
@@ -56,19 +78,27 @@ auto sudoku_board::set_corner_pencil_mark(i32 value) -> void
         }
     }
 
-    for (auto& cell : d_cells) {
-        if (cell.selected && !cell.fixed) {
-            if (add) {
+    for_each_selected([&](int x, int y, sudoku_cell& cell) {
+        if (add) {
+            if (!cell.corner_pencil_marks.contains(value)) {
+                event.changes[{x, y}].corner_marks_added.insert({x, y});
                 cell.corner_pencil_marks.insert(value);
-            } else {
+            }
+        } else {
+            if (cell.corner_pencil_marks.contains(value)) {
+                event.changes[{x, y}].corner_marks_removed.insert({x, y});
                 cell.corner_pencil_marks.erase(value);
             }
         }
-    }
+    });
+
+    d_history.add_event(event);
 }
 
 auto sudoku_board::set_centre_pencil_mark(i32 value) -> void
 {
+    auto event = edit_event{};
+
     // If any of the cells can accept the pencil mark, we are adding, otherwise
     // we are removing
     bool add = false;
@@ -81,15 +111,21 @@ auto sudoku_board::set_centre_pencil_mark(i32 value) -> void
         }
     }
 
-    for (auto& cell : d_cells) {
-        if (cell.selected && !cell.fixed) {
-            if (add) {
+    for_each_selected([&](int x, int y, sudoku_cell& cell) {
+        if (add) {
+            if (!cell.centre_pencil_marks.contains(value)) {
+                event.changes[{x, y}].centre_marks_added.insert({x, y});
                 cell.centre_pencil_marks.insert(value);
-            } else {
+            }
+        } else {
+            if (cell.centre_pencil_marks.contains(value)) {
+                event.changes[{x, y}].centre_marks_removed.insert({x, y});
                 cell.centre_pencil_marks.erase(value);
             }
         }
-    }
+    });
+
+    d_history.add_event(event);
 }
 
 namespace {
@@ -106,9 +142,12 @@ enum class delete_kind
 
 void sudoku_board::clear_selected()
 {
+    auto event = edit_event{};
+    
     const auto find_deletion_kind = [&] {
-        for (auto& cell : d_cells) {
-            if (cell.selected && !cell.fixed) {
+        for (i32 x = 0; x != d_size; ++x) {
+            for (i32 y = 0; y != d_size; ++y) {
+                auto& cell = get({x, y});
                 if (cell.value.has_value()) return delete_kind::digit;
                 if (!cell.centre_pencil_marks.empty()) return delete_kind::centre;
                 if (!cell.corner_pencil_marks.empty()) return delete_kind::corner;
@@ -119,28 +158,39 @@ void sudoku_board::clear_selected()
 
     switch (find_deletion_kind()) {
         case delete_kind::digit: {
-            for (auto& cell : d_cells) {
+            for_each_selected([&](int x, int y, sudoku_cell& cell) {
                 if (cell.selected && !cell.fixed) {
+                    event.changes[{x, y}].changed = true;
+                    event.changes[{x, y}].from = cell.value;
+                    event.changes[{x, y}].to = {};
                     cell.value = {};
                 }
-            }
+            });
         } break;
         case delete_kind::centre: {
-            for (auto& cell : d_cells) {
+            for_each_selected([&](int x, int y, sudoku_cell& cell) {
                 if (cell.selected && !cell.fixed) {
+                    for (auto value : cell.centre_pencil_marks) {
+                        event.changes[{x, y}].centre_marks_removed.insert(value);
+                    }
                     cell.centre_pencil_marks.clear();
                 }
-            }
+            });
         } break;
         case delete_kind::corner: {
-            for (auto& cell : d_cells) {
+            for_each_selected([&](int x, int y, sudoku_cell& cell) {
                 if (cell.selected && !cell.fixed) {
+                    for (auto value : cell.centre_pencil_marks) {
+                        event.changes[{x, y}].corner_marks_removed.insert(value);
+                    }
                     cell.corner_pencil_marks.clear();
                 }
-            }
+            });
         } break;
         case delete_kind::none: {} break;
     }
+
+    d_history.add_event(event);
 }
 
 void sudoku_board::undo()
@@ -158,7 +208,7 @@ auto sudoku_board::size() const -> u64
     return d_size;
 }
 
-auto sudoku_board::valid(glm::ivec2 pos) -> bool
+auto sudoku_board::valid(glm::ivec2 pos) const -> bool
 {
     return 0 <= pos.x && pos.x < d_size && 0 <= pos.y && pos.y < d_size;
 }

--- a/src/core/sudoku.cpp
+++ b/src/core/sudoku.cpp
@@ -8,32 +8,78 @@ sudoku_board::sudoku_board(u64 size)
 {
 }
 
-auto sudoku_board::at(i32 x, i32 y) -> sudoku_cell& {
-    assert(valid(x, y));
-    return d_cells[x + y * d_size];
+auto sudoku_board::get(glm::ivec2 pos) -> sudoku_cell&
+{
+    assert(valid(pos));
+    return d_cells[pos.x + pos.y * d_size];
 }
 
-auto sudoku_board::at(i32 x, i32 y) const -> const sudoku_cell& {
-    assert(valid(x, y));
-    return d_cells[x + y * d_size];
+auto sudoku_board::at(glm::ivec2 pos) const -> const sudoku_cell&
+{
+    assert(valid(pos));
+    return d_cells[pos.x + pos.y * d_size];
 }
 
-auto sudoku_board::size() const -> u64 {
+auto sudoku_board::select(glm::ivec2 pos, bool value) -> void
+{
+    assert(valid(pos));
+    get(pos).selected = value;
+}
+
+auto sudoku_board::toggle_selected(glm::ivec2 pos) -> void
+{
+    assert(valid(pos));
+    auto& cell = get(pos);
+    cell.selected = !cell.selected;
+}
+
+auto sudoku_board::set_digit(i32 value) -> void
+{
+    for (auto& cell : d_cells) {
+        if (cell.selected && !cell.fixed) {
+            cell.value = value;
+        }
+    }
+}
+
+auto sudoku_board::set_corner_pencil_mark(i32 value) -> void
+{
+    for (auto& cell : d_cells) {
+        if (cell.selected && !cell.fixed) {
+            cell.corner_pencil_marks.insert(value);
+        }
+    }
+}
+
+auto sudoku_board::set_centre_pencil_mark(i32 value) -> void
+{
+    for (auto& cell : d_cells) {
+        if (cell.selected && !cell.fixed) {
+            cell.centre_pencil_marks.insert(value);
+        }
+    }
+}
+
+
+auto sudoku_board::size() const -> u64
+{
     return d_size;
 }
 
-auto sudoku_board::valid(i32 x, i32 y) -> bool {
-    return 0 <= x && x < d_size && 0 <= y && y < d_size;
+auto sudoku_board::valid(glm::ivec2 pos) -> bool
+{
+    return 0 <= pos.x && pos.x < d_size && 0 <= pos.y && pos.y < d_size;
 }
 
-auto sudoku_board::clear_selected() -> void {
+auto sudoku_board::clear_selected() -> void 
+{
     for (auto& cell : d_cells) cell.selected = false;
 }
 
 auto sudoku_board::cells() -> std::vector<sudoku_cell>& { return d_cells; }
 auto sudoku_board::cells() const -> const std::vector<sudoku_cell>& { return d_cells; }
 
-auto make_board(std::vector<std::string_view> cells, std::vector<std::string_view> regions) -> sudoku_board
+auto sudoku_board::make_board(std::vector<std::string_view> cells, std::vector<std::string_view> regions) -> sudoku_board
 {
     const auto size = cells.size();
     if (regions.size() != size) {
@@ -51,10 +97,10 @@ auto make_board(std::vector<std::string_view> cells, std::vector<std::string_vie
         const auto& row = cells[y];
         for (int x = 0; x != row.size(); ++x) {
             if (row[x] != '.') {
-                board.at(x, y).value = static_cast<int>(row[x] - '0');
-                board.at(x, y).fixed = true;
+                board.get({x, y}).value = static_cast<int>(row[x] - '0');
+                board.get({x, y}).fixed = true;
             }
-            board.at(x, y).region = static_cast<i32>(regions[y][x] - '0');
+            board.get({x, y}).region = static_cast<i32>(regions[y][x] - '0');
         }
     }
     return board;

--- a/src/core/sudoku.cpp
+++ b/src/core/sudoku.cpp
@@ -51,7 +51,7 @@ auto sudoku_board::set_digit(i32 value) -> void
         for (i32 y = 0; y != d_size; ++y) {
             auto& cell = get({x, y});
             if (cell.selected && !cell.fixed) {
-                event.changes[{x, y}].changed = true;
+                event.changes[{x, y}].changed = cell.value != value;
                 event.changes[{x, y}].from = cell.value;
                 event.changes[{x, y}].to = value;
                 cell.value = value;
@@ -81,12 +81,12 @@ auto sudoku_board::set_corner_pencil_mark(i32 value) -> void
     for_each_selected([&](int x, int y, sudoku_cell& cell) {
         if (add) {
             if (!cell.corner_pencil_marks.contains(value)) {
-                event.changes[{x, y}].corner_marks_added.insert({x, y});
+                event.changes[{x, y}].corner_marks_added.insert(value);
                 cell.corner_pencil_marks.insert(value);
             }
         } else {
             if (cell.corner_pencil_marks.contains(value)) {
-                event.changes[{x, y}].corner_marks_removed.insert({x, y});
+                event.changes[{x, y}].corner_marks_removed.insert(value);
                 cell.corner_pencil_marks.erase(value);
             }
         }
@@ -114,12 +114,12 @@ auto sudoku_board::set_centre_pencil_mark(i32 value) -> void
     for_each_selected([&](int x, int y, sudoku_cell& cell) {
         if (add) {
             if (!cell.centre_pencil_marks.contains(value)) {
-                event.changes[{x, y}].centre_marks_added.insert({x, y});
+                event.changes[{x, y}].centre_marks_added.insert(value);
                 cell.centre_pencil_marks.insert(value);
             }
         } else {
             if (cell.centre_pencil_marks.contains(value)) {
-                event.changes[{x, y}].centre_marks_removed.insert({x, y});
+                event.changes[{x, y}].centre_marks_removed.insert(value);
                 cell.centre_pencil_marks.erase(value);
             }
         }
@@ -160,10 +160,10 @@ void sudoku_board::clear_selected()
         case delete_kind::digit: {
             for_each_selected([&](int x, int y, sudoku_cell& cell) {
                 if (cell.selected && !cell.fixed) {
-                    event.changes[{x, y}].changed = true;
+                    event.changes[{x, y}].changed = cell.value != std::nullopt;
                     event.changes[{x, y}].from = cell.value;
-                    event.changes[{x, y}].to = {};
-                    cell.value = {};
+                    event.changes[{x, y}].to = std::nullopt;
+                    cell.value = std::nullopt;
                 }
             });
         } break;
@@ -180,7 +180,7 @@ void sudoku_board::clear_selected()
         case delete_kind::corner: {
             for_each_selected([&](int x, int y, sudoku_cell& cell) {
                 if (cell.selected && !cell.fixed) {
-                    for (auto value : cell.centre_pencil_marks) {
+                    for (auto value : cell.corner_pencil_marks) {
                         event.changes[{x, y}].corner_marks_removed.insert(value);
                     }
                     cell.corner_pencil_marks.clear();
@@ -209,10 +209,10 @@ void sudoku_board::undo()
             get(pos).centre_pencil_marks.insert(val);
         }
         for (const auto val : change.corner_marks_added) {
-            get(pos).centre_pencil_marks.erase(val);
+            get(pos).corner_pencil_marks.erase(val);
         }
         for (const auto val : change.corner_marks_removed) {
-            get(pos).centre_pencil_marks.insert(val);
+            get(pos).corner_pencil_marks.insert(val);
         }
     }
 }
@@ -233,10 +233,10 @@ void sudoku_board::redo()
             get(pos).centre_pencil_marks.erase(val);
         }
         for (const auto val : change.corner_marks_added) {
-            get(pos).centre_pencil_marks.insert(val);
+            get(pos).corner_pencil_marks.insert(val);
         }
         for (const auto val : change.corner_marks_removed) {
-            get(pos).centre_pencil_marks.erase(val);
+            get(pos).corner_pencil_marks.erase(val);
         }
     }
 }

--- a/src/core/sudoku.cpp
+++ b/src/core/sudoku.cpp
@@ -195,12 +195,50 @@ void sudoku_board::clear_selected()
 
 void sudoku_board::undo()
 {
+    const auto event = d_history.go_back();
+    if (!event) return;
 
+    for (const auto& [pos, change] : event->changes) {
+        if (change.changed) {
+            get(pos).value = change.from;
+        }
+        for (const auto val : change.centre_marks_added) {
+            get(pos).centre_pencil_marks.erase(val);
+        }
+        for (const auto val : change.centre_marks_removed) {
+            get(pos).centre_pencil_marks.insert(val);
+        }
+        for (const auto val : change.corner_marks_added) {
+            get(pos).centre_pencil_marks.erase(val);
+        }
+        for (const auto val : change.corner_marks_removed) {
+            get(pos).centre_pencil_marks.insert(val);
+        }
+    }
 }
 
 void sudoku_board::redo()
 {
+    const auto event = d_history.go_forward();
+    if (!event) return;
 
+    for (const auto& [pos, change] : event->changes) {
+        if (change.changed) {
+            get(pos).value = change.to;
+        }
+        for (const auto val : change.centre_marks_added) {
+            get(pos).centre_pencil_marks.insert(val);
+        }
+        for (const auto val : change.centre_marks_removed) {
+            get(pos).centre_pencil_marks.erase(val);
+        }
+        for (const auto val : change.corner_marks_added) {
+            get(pos).centre_pencil_marks.insert(val);
+        }
+        for (const auto val : change.corner_marks_removed) {
+            get(pos).centre_pencil_marks.erase(val);
+        }
+    }
 }
 
 auto sudoku_board::size() const -> u64

--- a/src/core/sudoku.cpp
+++ b/src/core/sudoku.cpp
@@ -42,8 +42,20 @@ auto sudoku_board::set_digit(i32 value) -> void
     }
 }
 
-auto sudoku_board::set_corner_pencil_mark(i32 value, bool add) -> void
+auto sudoku_board::set_corner_pencil_mark(i32 value) -> void
 {
+    // If any of the cells can accept the pencil mark, we are adding, otherwise
+    // we are removing
+    bool add = false;
+    for (auto& cell : d_cells) {
+        if (cell.selected && !cell.fixed) {
+            if (!cell.corner_pencil_marks.contains(value)) {
+                add = true;
+                break;
+            }
+        }
+    }
+
     for (auto& cell : d_cells) {
         if (cell.selected && !cell.fixed) {
             if (add) {
@@ -55,8 +67,20 @@ auto sudoku_board::set_corner_pencil_mark(i32 value, bool add) -> void
     }
 }
 
-auto sudoku_board::set_centre_pencil_mark(i32 value, bool add) -> void
+auto sudoku_board::set_centre_pencil_mark(i32 value) -> void
 {
+    // If any of the cells can accept the pencil mark, we are adding, otherwise
+    // we are removing
+    bool add = false;
+    for (auto& cell : d_cells) {
+        if (cell.selected && !cell.fixed) {
+            if (!cell.centre_pencil_marks.contains(value)) {
+                add = true;
+                break;
+            }
+        }
+    }
+
     for (auto& cell : d_cells) {
         if (cell.selected && !cell.fixed) {
             if (add) {

--- a/src/core/sudoku.hpp
+++ b/src/core/sudoku.hpp
@@ -40,20 +40,24 @@ public:
     sudoku_board(u64 size);
 
     auto at(glm::ivec2 pos) const -> const sudoku_cell&;
+
     auto select(glm::ivec2 pos, bool value) -> void;
     auto toggle_selected(glm::ivec2 pos) -> void;
+    void unselect_all();
 
-    auto set_digit(i32 value) -> void;
-    auto set_corner_pencil_mark(i32 value) -> void;
-    auto set_centre_pencil_mark(i32 value) -> void;    
+    void set_digit(i32 value);
+    void set_corner_pencil_mark(i32 value, bool add);
+    void set_centre_pencil_mark(i32 value, bool add);  
+    
+    void clear_digits();
+    void clear_corner_pencil_marks();
+    void clear_centre_pencil_marks();
 
     auto size() const -> u64;
 
     auto valid(glm::ivec2 pos) -> bool;
 
-    auto clear_selected() -> void;
 
-    auto cells() -> std::vector<sudoku_cell>&;
     auto cells() const -> const std::vector<sudoku_cell>&;
     
     static auto make_board(std::vector<std::string_view> cells, std::vector<std::string_view> regions) -> sudoku_board;

--- a/src/core/sudoku.hpp
+++ b/src/core/sudoku.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "common.hpp"
+#include "solve_history.hpp"
 
 #include <optional>
 #include <vector>
@@ -31,8 +32,9 @@ struct sudoku_region
 
 class sudoku_board
 {
-    u64                            d_size;
-    std::vector<sudoku_cell>       d_cells;
+    u64                      d_size;
+    std::vector<sudoku_cell> d_cells;
+    solve_history            d_history;
 
     auto get(glm::ivec2 pos) -> sudoku_cell&;
 
@@ -41,22 +43,27 @@ public:
 
     auto at(glm::ivec2 pos) const -> const sudoku_cell&;
 
+    // Selection API
     auto select(glm::ivec2 pos, bool value) -> void;
     auto toggle_selected(glm::ivec2 pos) -> void;
     void unselect_all();
 
+    // Modify the selected cells
     void set_digit(i32 value);
     void set_corner_pencil_mark(i32 value);
     void set_centre_pencil_mark(i32 value);  
     
-    void clear_digits();
-    void clear_corner_pencil_marks();
-    void clear_centre_pencil_marks();
+    // Clears the selected cells. It will clear digits if there are any,
+    // followed by centre pencil marks if there are no digits, followed by
+    // corner pencil marks if there are no centre pencil marks.
+    void clear_selected();
+
+    // History API
+    void undo();
+    void redo();
 
     auto size() const -> u64;
-
     auto valid(glm::ivec2 pos) -> bool;
-
 
     auto cells() const -> const std::vector<sudoku_cell>&;
     

--- a/src/core/sudoku.hpp
+++ b/src/core/sudoku.hpp
@@ -34,22 +34,30 @@ class sudoku_board
     u64                            d_size;
     std::vector<sudoku_cell>       d_cells;
 
+    auto get(glm::ivec2 pos) -> sudoku_cell&;
+
 public:
     sudoku_board(u64 size);
 
-    auto at(i32 x, i32 y) -> sudoku_cell&;
-    auto at(i32 x, i32 y) const -> const sudoku_cell&;
+    auto at(glm::ivec2 pos) const -> const sudoku_cell&;
+    auto select(glm::ivec2 pos, bool value) -> void;
+    auto toggle_selected(glm::ivec2 pos) -> void;
+
+    auto set_digit(i32 value) -> void;
+    auto set_corner_pencil_mark(i32 value) -> void;
+    auto set_centre_pencil_mark(i32 value) -> void;    
 
     auto size() const -> u64;
 
-    auto valid(i32 x, i32 y) -> bool;
+    auto valid(glm::ivec2 pos) -> bool;
 
     auto clear_selected() -> void;
 
     auto cells() -> std::vector<sudoku_cell>&;
     auto cells() const -> const std::vector<sudoku_cell>&;
+    
+    static auto make_board(std::vector<std::string_view> cells, std::vector<std::string_view> regions) -> sudoku_board;
 };
 
-auto make_board(std::vector<std::string_view> cells, std::vector<std::string_view> regions) -> sudoku_board;
 
 }

--- a/src/core/sudoku.hpp
+++ b/src/core/sudoku.hpp
@@ -37,6 +37,7 @@ class sudoku_board
     solve_history            d_history;
 
     auto get(glm::ivec2 pos) -> sudoku_cell&;
+    auto for_each_selected(const std::function<void(int, int, sudoku_cell&)>& fn); // TODO: Replace with function_ref
 
 public:
     sudoku_board(u64 size);
@@ -63,12 +64,11 @@ public:
     void redo();
 
     auto size() const -> u64;
-    auto valid(glm::ivec2 pos) -> bool;
+    auto valid(glm::ivec2 pos) const -> bool;
 
     auto cells() const -> const std::vector<sudoku_cell>&;
     
     static auto make_board(std::vector<std::string_view> cells, std::vector<std::string_view> regions) -> sudoku_board;
 };
-
 
 }

--- a/src/core/sudoku.hpp
+++ b/src/core/sudoku.hpp
@@ -46,8 +46,8 @@ public:
     void unselect_all();
 
     void set_digit(i32 value);
-    void set_corner_pencil_mark(i32 value, bool add);
-    void set_centre_pencil_mark(i32 value, bool add);  
+    void set_corner_pencil_mark(i32 value);
+    void set_centre_pencil_mark(i32 value);  
     
     void clear_digits();
     void clear_corner_pencil_marks();

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -6,7 +6,6 @@
 #include "ui.hpp"
 #include "sudoku.hpp"
 #include "draw_board.hpp"
-#include "solve_history.hpp"
 
 #define GLM_ENABLE_EXPERIMENTAL
 #include <glm/glm.hpp>
@@ -115,36 +114,6 @@ void flip(std::set<i32>& ints, i32 value)
     }
 }
 
-auto has_any_value(const sudoku_board& board) -> bool
-{
-    for (auto& cell : board.cells()) {
-        if (cell.selected && !cell.fixed) {
-            if (cell.value.has_value()) return true;
-        }
-    }
-    return false;
-}
-
-auto has_any_centre_pencil_marks(const sudoku_board& board) -> bool
-{
-    for (auto& cell : board.cells()) {
-        if (cell.selected && !cell.fixed) {
-            if (!cell.centre_pencil_marks.empty()) return true;
-        }
-    }
-    return false;
-}
-
-auto has_any_corner_pencil_marks(const sudoku_board& board) -> bool
-{
-    for (auto& cell : board.cells()) {
-        if (cell.selected && !cell.fixed) {
-            if (!cell.corner_pencil_marks.empty()) return true;
-        }
-    }
-    return false;
-}
-
 }
 
 auto scene_main_menu(sudoku::window& window) -> next_state
@@ -208,7 +177,6 @@ auto scene_game(sudoku::window& window) -> next_state
     auto timer    = sudoku::timer{};
     auto renderer = sudoku::renderer{};
     auto ui       = sudoku::ui_engine{&renderer};
-    auto history  = sudoku::solve_history{};
 
     auto state = board_render_state{ normal_rs{} };
 
@@ -339,13 +307,7 @@ auto scene_game(sudoku::window& window) -> next_state
                 std::optional<i32> value = {};
                 switch (e->key) {
                     case keyboard::backspace: {
-                        if (has_any_value(board)) {
-                            board.clear_digits();
-                        } else if (has_any_centre_pencil_marks(board)) {
-                            board.clear_centre_pencil_marks();
-                        } else if (has_any_corner_pencil_marks(board)) {
-                            board.clear_corner_pencil_marks();
-                        }
+                        board.clear_selected();
                     } break;
                     case keyboard::escape: {
                         board.unselect_all();

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -105,15 +105,6 @@ auto check_solution(const sudoku_board& board, time_point time) -> board_render_
     return solved_rs{ .time = time };
 }
 
-void flip(std::set<i32>& ints, i32 value)
-{
-    if (ints.contains(value)) {
-        ints.erase(value);
-    } else {
-        ints.insert(value);
-    }
-}
-
 }
 
 auto scene_main_menu(sudoku::window& window) -> next_state

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -129,24 +129,7 @@ void update_centre_pencil_mark(sudoku_board& board, i32 value)
         }
     }
 
-    for (auto& cell : board.cells()) {
-        if (cell.selected && !cell.fixed) {
-            if (add) {
-                cell.centre_pencil_marks.insert(value);
-            } else {
-                cell.centre_pencil_marks.erase(value);
-            }
-        }
-    }
-}
-
-void clear_centre_pencil_mark(sudoku_board& board)
-{
-    for (auto& cell : board.cells()) {
-        if (cell.selected && !cell.fixed) {
-            cell.centre_pencil_marks.clear();
-        }
-    }
+    board.set_centre_pencil_mark(value, add);
 }
 
 void update_corner_pencil_mark(sudoku_board& board, i32 value)
@@ -163,42 +146,7 @@ void update_corner_pencil_mark(sudoku_board& board, i32 value)
         }
     }
 
-    for (auto& cell : board.cells()) {
-        if (cell.selected && !cell.fixed) {
-            if (add) {
-                cell.corner_pencil_marks.insert(value);
-            } else {
-                cell.corner_pencil_marks.erase(value);
-            }
-        }
-    }
-}
-
-void clear_corner_pencil_mark(sudoku_board& board)
-{
-    for (auto& cell : board.cells()) {
-        if (cell.selected && !cell.fixed) {
-            cell.corner_pencil_marks.clear();
-        }
-    }
-}
-
-void set_value(sudoku_board& board, i32 value)
-{
-    for (auto& cell : board.cells()) {
-        if (cell.selected && !cell.fixed) {
-            cell.value = value;
-        }
-    }
-}
-
-void remove_value(sudoku_board& board)
-{
-    for (auto& cell : board.cells()) {
-        if (cell.selected && !cell.fixed) {
-            cell.value = {};
-        }
-    }
+    board.set_corner_pencil_mark(value, add);
 }
 
 auto has_any_value(const sudoku_board& board) -> bool
@@ -399,13 +347,13 @@ auto scene_game(sudoku::window& window) -> next_state
                         if (e->mods & modifier::shift) {
                             board.toggle_selected(*pos);
                         } else {
-                            board.clear_selected();
+                            board.unselect_all();
                             board.select(*pos, true);
                         }
                         mouse_down = std::as_const(board).at(*pos).selected;
                     }
                 } else {
-                    board.clear_selected();
+                    board.unselect_all();
                 }
             }
             else if (auto e = event.get_if<mouse_released_event>()) {
@@ -426,15 +374,15 @@ auto scene_game(sudoku::window& window) -> next_state
                 switch (e->key) {
                     case keyboard::backspace: {
                         if (has_any_value(board)) {
-                            remove_value(board);
+                            board.clear_digits();
                         } else if (has_any_centre_pencil_marks(board)) {
-                            clear_centre_pencil_mark(board);
+                            board.clear_centre_pencil_marks();
                         } else if (has_any_corner_pencil_marks(board)) {
-                            clear_corner_pencil_mark(board);
+                            board.clear_corner_pencil_marks();
                         }
                     } break;
                     case keyboard::escape: {
-                        board.clear_selected();
+                        board.unselect_all();
                     } break;
                     case keyboard::num_1: value = 1; break;
                     case keyboard::num_2: value = 2; break;
@@ -456,7 +404,7 @@ auto scene_game(sudoku::window& window) -> next_state
                     update_corner_pencil_mark(board, *value);
                 }
                 else {
-                    set_value(board, *value);
+                    board.set_digit(*value);
                 }
             }
         }

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -265,7 +265,7 @@ auto scene_game(sudoku::window& window) -> next_state
                 continue; // Don't allow updating the board when it's solved
             }
 
-            if (auto e = event.get_if<mouse_pressed_event>()) {
+            if (const auto e = event.get_if<mouse_pressed_event>()) {
                 const auto pos = hovered_cell_pos(board, window);
                 if (pos.has_value() && board.valid(*pos)) {
                     if (e->button == mouse::left) {
@@ -281,12 +281,12 @@ auto scene_game(sudoku::window& window) -> next_state
                     board.unselect_all();
                 }
             }
-            else if (auto e = event.get_if<mouse_released_event>()) {
+            else if (const auto e = event.get_if<mouse_released_event>()) {
                 if (e->button == mouse::left) {
                     mouse_down = {};
                 }
             }
-            else if (auto e = event.get_if<mouse_moved_event>()) {
+            else if (const auto e = event.get_if<mouse_moved_event>()) {
                 if (mouse_down.has_value()) {
                     auto cell = hovered_cell_pos(board, window);
                     if (cell.has_value() && board.valid(*cell)) {
@@ -294,7 +294,7 @@ auto scene_game(sudoku::window& window) -> next_state
                     }
                 }
             }
-            else if (auto e = event.get_if<keyboard_pressed_event>()) {
+            else if (const auto e = event.get_if<keyboard_pressed_event>()) {
                 std::optional<i32> value = {};
                 switch (e->key) {
                     case keyboard::Z: {
@@ -334,6 +334,20 @@ auto scene_game(sudoku::window& window) -> next_state
                 }
                 else {
                     board.set_digit(*value);
+                }
+            }
+            else if (auto e = event.get_if<keyboard_held_event>()) {
+                switch (e->key) {
+                    case keyboard::Z: {
+                        if (e->mods & modifier::ctrl) {
+                            board.undo();
+                        }
+                    } break;
+                    case keyboard::Y: {
+                        if (e->mods & modifier::ctrl) {
+                            board.redo();
+                        }
+                    } break;
                 }
             }
         }

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -306,6 +306,16 @@ auto scene_game(sudoku::window& window) -> next_state
             else if (auto e = event.get_if<keyboard_pressed_event>()) {
                 std::optional<i32> value = {};
                 switch (e->key) {
+                    case keyboard::Z: {
+                        if (e->mods & modifier::ctrl) {
+                            board.undo();
+                        }
+                    } break;
+                    case keyboard::Y: {
+                        if (e->mods & modifier::ctrl) {
+                            board.redo();
+                        }
+                    } break;
                     case keyboard::backspace: {
                         board.clear_selected();
                     } break;

--- a/src/game.m.cpp
+++ b/src/game.m.cpp
@@ -115,40 +115,6 @@ void flip(std::set<i32>& ints, i32 value)
     }
 }
 
-void update_centre_pencil_mark(sudoku_board& board, i32 value)
-{
-    // If any of the cells can accept the pencil mark, we are adding, otherwise
-    // we are removing
-    bool add = false;
-    for (auto& cell : board.cells()) {
-        if (cell.selected && !cell.fixed) {
-            if (!cell.centre_pencil_marks.contains(value)) {
-                add = true;
-                break;
-            }
-        }
-    }
-
-    board.set_centre_pencil_mark(value, add);
-}
-
-void update_corner_pencil_mark(sudoku_board& board, i32 value)
-{
-    // If any of the cells can accept the pencil mark, we are adding, otherwise
-    // we are removing
-    bool add = false;
-    for (auto& cell : board.cells()) {
-        if (cell.selected && !cell.fixed) {
-            if (!cell.corner_pencil_marks.contains(value)) {
-                add = true;
-                break;
-            }
-        }
-    }
-
-    board.set_corner_pencil_mark(value, add);
-}
-
 auto has_any_value(const sudoku_board& board) -> bool
 {
     for (auto& cell : board.cells()) {
@@ -398,10 +364,10 @@ auto scene_game(sudoku::window& window) -> next_state
                 if (*value > board.size()) continue; // not a digit in the grid
 
                 if (e->mods & modifier::ctrl) {
-                    update_centre_pencil_mark(board, *value);
+                    board.set_centre_pencil_mark(*value);
                 }
                 else if (e->mods & modifier::shift) {
-                    update_corner_pencil_mark(board, *value);
+                    board.set_corner_pencil_mark(*value);
                 }
                 else {
                     board.set_digit(*value);


### PR DESCRIPTION
* When filling in the board, you can now ctrl-Z to undo changes to the board, and ctrl-Y to redo them.
* If you ctrl-Z back a few steps and then start editing again, the old history is lost, just like how undo works in other programs.
* The history is capped to 1024 events, after which the oldest start getting ejected, but that's way higher than anyone would need.
* You can hold down the keys to quickly undo/redo multiple times.
* A massive refactor of the sudoku updating code; now the sudoku class is more locked down, so you can only update it through the interface, which made it easier to see where to update the history. A lot of code has moves out of the main file and into the board file.